### PR TITLE
Add support for generics in arrow functions and void return types.

### DIFF
--- a/tests/generics-test.el
+++ b/tests/generics-test.el
@@ -5,7 +5,7 @@
 (describe "Generics support"
 
   (it "should parse a generic marker after a function keyword"
-    (flow-js2-deftest-parse "function f<T>() {};"))
+    (flow-js2-deftest-parse "var f = function <T>() {};"))
 
   (it "should parse a generic marker after a function keyword"
     (flow-js2-deftest-parse "<T>() => {};"))

--- a/tests/generics-test.el
+++ b/tests/generics-test.el
@@ -5,4 +5,8 @@
 (describe "Generics support"
 
   (it "should parse a generic marker after a function keyword"
-    (flow-js2-deftest-parse "(function<T>() {})")))
+    (flow-js2-deftest-parse "function f<T>() {};"))
+
+  (it "should parse a generic marker after a function keyword"
+    (flow-js2-deftest-parse "<T>() => {};"))
+  )


### PR DESCRIPTION
Also removing 'flow-js2-parse-named-prop seems to fix issue #4. There wasn't a test covering it, but trying the example in the linked issue seems to work with this removed.  There also seems to be an issue with the generics-test.el even in the current HEAD.  I plan to take a look at it at some point, but it's no worse off after this change.

Please let me know if you have any questions.

Regards,
-Doug
